### PR TITLE
feat: extend WalletConnect namespaces for BSC + Base, add chain-management methods

### DIFF
--- a/lib/components/wallet-qr.tsx
+++ b/lib/components/wallet-qr.tsx
@@ -19,22 +19,39 @@ const walletConnectConfig:UniversalProviderOpts = {
   },
 }
 
+const EIP155_METHODS = [
+  'eth_sendTransaction',
+  'eth_signTransaction',
+  'eth_sign',
+  'personal_sign',
+  'eth_signTypedData',
+  'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
+  'wallet_switchEthereumChain',
+  'wallet_addEthereumChain',
+]
+
+const EIP155_EVENTS = ['chainChanged', 'accountsChanged', 'disconnect']
+
 const walletProviderConnectConfig = {
   namespaces: {
     eip155: {
-      methods: [
-        'eth_sendTransaction',
-        'eth_signTransaction',
-        'eth_sign',
-        'personal_sign',
-        'eth_signTypedData',
-        'eth_signTypedData_v3',
-        'eth_signTypedData_v4',
-      ],
-      chains: ['eip155:1'],
-      events: ['chainChanged', 'accountsChanged', 'disconnect'],
+      methods: EIP155_METHODS,
+      chains: ['eip155:56'],
+      events: EIP155_EVENTS,
       rpcMap: {
-        1: `https://rpc.walletconnect.com?chainId=eip155:1&projectId=${WALLETCONNECT_PROJECT_ID}`,
+        56: 'https://bsc-dataseed.binance.org',
+      },
+    },
+  },
+  optionalNamespaces: {
+    eip155: {
+      methods: EIP155_METHODS,
+      chains: ['eip155:8453', 'eip155:84532'],
+      events: EIP155_EVENTS,
+      rpcMap: {
+        8453: 'https://mainnet.base.org',
+        84532: 'https://sepolia.base.org',
       },
     },
   },

--- a/lib/components/wallet-qr.tsx
+++ b/lib/components/wallet-qr.tsx
@@ -28,6 +28,8 @@ const walletProviderConnectConfig = {
         'eth_sign',
         'personal_sign',
         'eth_signTypedData',
+        'eth_signTypedData_v3',
+        'eth_signTypedData_v4',
       ],
       chains: ['eip155:1'],
       events: ['chainChanged', 'accountsChanged', 'disconnect'],


### PR DESCRIPTION
## Summary
- **Methods**: add `eth_signTypedData_v3`, `eth_signTypedData_v4`, `wallet_switchEthereumChain`, `wallet_addEthereumChain` to the `eip155` methods whitelist so viem `signTypedData` calls and chain-switch prompts reach the remote wallet over WalletConnect.
- **Chain topology**: move required chain from `eip155:1` to `eip155:56` (BSC — the primary business chain). Introduce `optionalNamespaces` for `eip155:8453` (Base mainnet) and `eip155:84532` (Base sepolia).
- **rpcMap**: replace the placeholder `eip155:1` WalletConnect proxy entry with public RPC endpoints keyed by the actual business chain IDs (`56`, `8453`, `84532`).
- **Refactor**: factor out `EIP155_METHODS` and `EIP155_EVENTS` to avoid duplicating the whitelist across required and optional namespaces.

## Out of scope
- SIWE message currently hardcodes `chainId: 1`. Plan is to switch it to the actual session chain ID, but that requires reading the chain from the connected session (signature change for `getSiweMessage`) — splitting to a follow-up PR.

## Test plan
- [ ] Connect a WalletConnect-based wallet via the QR flow and verify the session is established with `eip155:56` as the active chain.
- [ ] Trigger a `signTypedData` flow from a consumer app on BSC — verify the request reaches the wallet and signs successfully.
- [ ] If the wallet supports Base, verify chain-switch prompts (`wallet_switchEthereumChain`) work against `eip155:8453` / `eip155:84532`.

> Note: this PR only changes a WalletConnect handshake config; TS build passes locally. Real verification requires a live WalletConnect session — not covered by automated tests.