### PR TITLE
feat: port WalletConnect typed-data v3/v4 + BSC/Base namespaces to feat/captcha

### DIFF
--- a/lib/components/wallet-qr.tsx
+++ b/lib/components/wallet-qr.tsx
@@ -28,6 +28,8 @@ const walletProviderConnectConfig = {
         'eth_sign',
         'personal_sign',
         'eth_signTypedData',
+        'eth_signTypedData_v3',
+        'eth_signTypedData_v4',
       ],
       chains: ['eip155:56'],
       events: ['chainChanged', 'accountsChanged', 'disconnect'],

--- a/lib/components/wallet-qr.tsx
+++ b/lib/components/wallet-qr.tsx
@@ -19,22 +19,39 @@ const walletConnectConfig:UniversalProviderOpts = {
   },
 }
 
+const EIP155_METHODS = [
+  'eth_sendTransaction',
+  'eth_signTransaction',
+  'eth_sign',
+  'personal_sign',
+  'eth_signTypedData',
+  'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
+  'wallet_switchEthereumChain',
+  'wallet_addEthereumChain',
+]
+
+const EIP155_EVENTS = ['chainChanged', 'accountsChanged', 'disconnect']
+
 const walletProviderConnectConfig = {
   namespaces: {
     eip155: {
-      methods: [
-        'eth_sendTransaction',
-        'eth_signTransaction',
-        'eth_sign',
-        'personal_sign',
-        'eth_signTypedData',
-        'eth_signTypedData_v3',
-        'eth_signTypedData_v4',
-      ],
+      methods: EIP155_METHODS,
       chains: ['eip155:56'],
-      events: ['chainChanged', 'accountsChanged', 'disconnect'],
+      events: EIP155_EVENTS,
       rpcMap: {
-        1: `https://rpc.walletconnect.com?chainId=eip155:56&projectId=${WALLETCONNECT_PROJECT_ID}`,
+        56: 'https://bsc-dataseed.binance.org',
+      },
+    },
+  },
+  optionalNamespaces: {
+    eip155: {
+      methods: EIP155_METHODS,
+      chains: ['eip155:8453', 'eip155:84532'],
+      events: EIP155_EVENTS,
+      rpcMap: {
+        8453: 'https://mainnet.base.org',
+        84532: 'https://sepolia.base.org',
       },
     },
   },


### PR DESCRIPTION
## Summary
Port the changes already merged to `main` (PR #3) onto `feat/captcha`, so the captcha branch picks up the WalletConnect namespace + RPC fixes alongside its in-flight work.

Cherry-picked commits:
- `266b1a0` — feat: add eth_signTypedData_v3 and v4 to WalletConnect methods
- `2e8e923` — feat: extend WalletConnect namespaces for BSC + Base chains

Combined effect on `lib/components/wallet-qr.tsx`:
- **Methods**: add `eth_signTypedData_v3`, `eth_signTypedData_v4`, `wallet_switchEthereumChain`, `wallet_addEthereumChain` to the `eip155` whitelist.
- **Chain topology**: keep `eip155:56` as required (BSC). Add `optionalNamespaces` for `eip155:8453` (Base mainnet) and `eip155:84532` (Base sepolia).
- **rpcMap**: replace the half-fixed `1: '?chainId=eip155:56...'` entry on this branch with proper per-chain public RPC endpoints (`56`, `8453`, `84532`).
- **Refactor**: factor out `EIP155_METHODS` / `EIP155_EVENTS` so required and optional namespaces share one source of truth.

## Conflict resolution note
The 2nd cherry-pick (`2e8e923`) hit a conflict in `wallet-qr.tsx`: `feat/captcha` had already moved `chains` to `eip155:56` but left `rpcMap` keyed at `1` (with `chainId=eip155:56` in the URL — a half-applied fix). Took the incoming version, which completes that fix and adds the optionalNamespaces block.

## Test plan
- [ ] Connect a WalletConnect wallet via the QR flow on this branch — session should establish with `eip155:56` active and `bsc-dataseed.binance.org` as the RPC.
- [ ] Trigger a `signTypedData` flow from a captcha-flow consumer — request reaches the wallet.
- [ ] If wallet supports Base, verify chain-switch / chain-add prompts work for `eip155:8453` / `eip155:84532`.

> Note: TS build passes locally; real verification needs a live WalletConnect session.