### PR TITLE
fix: move all chains into optionalNamespaces to prevent BSC drop

### DIFF
--- a/lib/components/wallet-qr.tsx
+++ b/lib/components/wallet-qr.tsx
@@ -34,22 +34,15 @@ const EIP155_METHODS = [
 const EIP155_EVENTS = ['chainChanged', 'accountsChanged', 'disconnect']
 
 const walletProviderConnectConfig = {
-  namespaces: {
-    eip155: {
-      methods: EIP155_METHODS,
-      chains: ['eip155:56'],
-      events: EIP155_EVENTS,
-      rpcMap: {
-        56: 'https://bsc-dataseed.binance.org',
-      },
-    },
-  },
+  // requiredNamespaces is deprecated in WalletConnect (CAIP-25); wallets like
+  // OKX only read optionalNamespaces, so all chains must live here.
   optionalNamespaces: {
     eip155: {
       methods: EIP155_METHODS,
-      chains: ['eip155:8453', 'eip155:84532'],
+      chains: ['eip155:56', 'eip155:8453', 'eip155:84532'],
       events: EIP155_EVENTS,
       rpcMap: {
+        56: 'https://bsc-dataseed.binance.org',
         8453: 'https://mainnet.base.org',
         84532: 'https://sepolia.base.org',
       },


### PR DESCRIPTION
## Problem

After upgrading `@walletconnect/universal-provider` to ^2.23.0 (shipped in npm 2.8.5), the WalletConnect QR session proposal lost the BSC chain — wallets only showed Base and Base Sepolia.

## Root cause

universal-provider 2.23 deprecates required namespaces: `setNamespaces` merges the `namespaces` option into `optionalNamespaces` and sends `requiredNamespaces: {}`. The merge is a lodash-style deep merge that combines arrays **index-wise**, so:

```
namespaces.eip155.chains         = ['eip155:56']
optionalNamespaces.eip155.chains = ['eip155:8453', 'eip155:84532']
merged                           = ['eip155:8453', 'eip155:84532']   // BSC overwritten at index 0
```

(Under the previous universal-provider 2.17.x, `namespaces` was passed through as `requiredNamespaces`, which is why BSC used to appear.)

## Fix

Declare all three chains in `optionalNamespaces.eip155.chains` with a full `rpcMap` and drop the `namespaces` key entirely, so the lossy merge has nothing to clobber. Verified the built bundle (with the 2.23.0 lockfile deps) contains all of eip155:56 / 8453 / 84532 in the proposal config.

`dist/` is intentionally not included; rebuild before publishing.

## Test plan

- [ ] Scan the WalletConnect QR with OKX and confirm the session proposal lists BSC, Base, and Base Sepolia